### PR TITLE
use light with Firefox+SwitchyOmega

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -127,6 +127,18 @@
 <li>choose the profile you created above</li>
 <li>enjoy</li>
 </ol>
+<h4 id="firefoxswitchyomega">Firefox+SwitchyOmega</h4>
+<ol>
+<li>install <a href="https://www.mozilla.org/firefox/new/">Firefox</a></li>
+<li>install plugin <a href="https://addons.mozilla.org/en-US/firefox/addon/switchyomega/">Proxy SwitchyOmega</a>, and better follow the guide</li>
+<li>SwitchyOmega Option -> New profile -> Proxy -> create</li>
+<li>choose default protocol <code>HTTPS</code>, Server <code>light.ustclug.org</code>, Port <code>29980</code></li>
+<li>fill in your account after clicking the lock, password is at the beginning of the this page</li>
+<li>click "Apply changes" button</li>
+<li>choose the profile you created above, and <strong>set it as default</strong> at the interface (SETTINGS -> Interface -> Switch Options -> Startup Profile)</li>
+<li>Restart firefox</li>
+<li>enjoy</li>
+</ol>
 <h4 id="iosdeviceios93orlater">iOS device (iOS 9.3 or later)</h4>
 <ol>
 <li>Install <strong>Wingy</strong> via App Store</li>


### PR DESCRIPTION
add instructions for using light with Firefox and SwitchyOmega.

On second thought, I find that I just know the plugin [Proxy SwitchyOmega](https://addons.mozilla.org/en-US/firefox/addon/switchyomega/)'s document gives links to the repository on Github and other information, but I don't know how to find out whether it is of the same author for the plugin on Chome.  (feeling a little uncertain)

Advice appreciated.