### PR TITLE
Remove MySQL view in `month_traffic()` and `last_month_traffic()`

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -259,7 +259,7 @@ class User(db.Model, UserMixin):
             where 
                 ((month(radius.radacct.acctstarttime) = month(now())) and 
                 (year(radius.radacct.acctstarttime) = year(now()))) and 
-                radius.radacct.username = %s
+                radius.radacct.username = %s;
         """, self.email).first()
         return sizeof_fmt(float(r[0]) if r else 0)
 
@@ -272,7 +272,7 @@ class User(db.Model, UserMixin):
             where 
                 ((month(radius.radacct.acctstarttime) = month(now(),interval 1 month)) and 
                 (year(radius.radacct.acctstarttime) = year(now(),interval 1 month))) and 
-                radius.radacct.username = %s
+                radius.radacct.username = %s;
         """, self.email).first()
         return sizeof_fmt(float(r[0]) if r else 0)
 

--- a/scripts/create_views.py
+++ b/scripts/create_views.py
@@ -23,9 +23,7 @@ cur.execute("""
             ((month(radius.radacct.acctstarttime) = month(date_sub(now(),interval 1 month))) and
             (year(radius.radacct.acctstarttime) = year(date_sub(now(),interval 1 month))))
         group by
-            radius.radacct.username
-        order by
-            (sum((radius.radacct.acctinputoctets + radius.radacct.acctoutputoctets)));
+            radius.radacct.username;
     """)
 cur.execute("""
         CREATE OR REPLACE VIEW radius.monthtraffic AS
@@ -38,9 +36,7 @@ cur.execute("""
             ((month(radius.radacct.acctstarttime) = month(now())) and
             (year(radius.radacct.acctstarttime) = year(now())))
         group by
-            radius.radacct.username
-        order by
-            (sum((radius.radacct.acctinputoctets + radius.radacct.acctoutputoctets)));
+            radius.radacct.username;
         """)
 
 db.close()


### PR DESCRIPTION
By rewriting SQL query in these two functions, the speed of loading user's traffic improves from about ~1s to < 0.01s.

That's because when handling with original query, MySQL uses 'temp tables': building whole view first (which takes significant long time when `radacct` is large), and then filtering.